### PR TITLE
Fix/reloading screen while refreshing

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -138,6 +138,10 @@ If set to true, this will expose a `/__refresh` webhook that is able to receive 
 
 You can trigger this endpoint locally, for example, on Unix-based operating systems (like Ubuntu and MacOS) using `curl -X POST http://localhost:8000/__refresh`.
 
+- `ENABLE_GATSBY_RESTARTING_SCREEN_ON_REFRESH`
+
+If set to true, this will show the restarting screen when the refresh endpoint is hit, until the refresh finishes.
+
 ## Build Variables
 
 Gatsby uses additional environment variables in the build step to fine-tune the outcome of a build. You may find these helpful for more advanced configurations, such as using [CI/CD](https://en.wikipedia.org/wiki/CI/CD) to deploy a Gatsby site.

--- a/docs/docs/running-a-gatsby-preview-server.md
+++ b/docs/docs/running-a-gatsby-preview-server.md
@@ -12,6 +12,7 @@ Roughly, you can follow these steps to enable your own preview server:
 
 - Run `gatsby develop` on a Node.js host like [Heroku](/docs/deploying-to-heroku/) with the [ENABLE_GATSBY_REFRESH_ENDPOINT environment variable](/docs/environment-variables/#reserved-environment-variables) enabled. This will configure the develop server to re-source data when it receives a `POST` request to `/__refresh`.
 - Then setup your CMS to ping this URL on the preview server whenever content is changed.
+- if you want to show a restarting screen when the refresh endpoint is hit until it finishes refreshing add the [ENABLE_GATSBY_RESTARTING_SCREEN_ON_REFRESH environment variable](/docs/environment-variables/#reserved-environment-variables)
 
 ## Using Gatsby Cloud Preview
 

--- a/e2e-tests/development-refresh-endpoint/cypress/integration/functionality/refresh-endpoint.js
+++ b/e2e-tests/development-refresh-endpoint/cypress/integration/functionality/refresh-endpoint.js
@@ -1,22 +1,69 @@
-describe(`When the refresh endpoint is hit multiple times`, () => {
-  
-  it(`should put new requests with unique body in a queue`, () => {
-    cy.request(`POST`, `/__refresh`).then(response => {
-      expect(response.body).to.be.equal(``)
+describe(`When the refresh endpoint is hit`, () => {
+  afterEach(() => {
+    waitUntilRefreshFinishes()
+  })
+
+  describe(`and accessing any page while refreshing`, () => {
+    it(`the page shown should be restarting page for 404 page`, () => {
+      cy.request(`/non-existing`).then(response => {
+        expect(response.body).not.to.include(`<title>Restarting...</title>`)
+      })
+      cy.request(`POST`, `/__refresh`)
+      cy.request(`/non-existing`).then(response => {
+        expect(response.body).to.include(`<title>Restarting...</title>`)
+      })
     })
-    cy.request(`POST`, `/__refresh`).then(response => {
-      expect(response.body).to.include(`queued`)
-    })
-    cy.request(`POST`, `/__refresh`).then(response => {
-      expect(response.body).to.include(`already queued`)
-    })
-    cy.request(`POST`, `/__refresh`, `otherBody`).then(response => {
-      expect(response.body).to.include(`queued`)
-    })
-    cy.request(`POST`, `/__refresh`, `otherBody`).then(response => {
-      expect(response.body).to.include(`already queued`)
+
+    it(`the page shown should be restarting page for existing pages`, () => {
+      cy.request(`/page-2/`).then(response => {
+        expect(response.body).not.to.include(`<title>Restarting...</title>`)
+      })
+      cy.request(`POST`, `/__refresh`)
+      cy.request(`/page-2/`).then(response => {
+        expect(response.body).to.include(`<title>Restarting...</title>`)
+      })
     })
   })
 
+  describe(`and it was not already refreshing`, () => {
+    it(`should return empty body`, () => {
+      cy.request(`POST`, `/__refresh`).then(response => {
+        expect(response.body).to.be.equal(``)
+      })
+    })
+  })
+  describe(`and it was already refreshing`, () => {
+    it(`should put new requests with unique body in a queue`, () => {
+      cy.request(`POST`, `/__refresh`).then(response => {
+        expect(response.body).to.be.equal(``)
+      })
+      cy.request(`POST`, `/__refresh`).then(response => {
+        expect(response.body).to.include(`queued`)
+      })
+      cy.request(`POST`, `/__refresh`).then(response => {
+        expect(response.body).to.include(`already queued`)
+      })
+      cy.request(`POST`, `/__refresh`, `otherBody`).then(response => {
+        expect(response.body).to.include(`queued`)
+      })
+      cy.request(`POST`, `/__refresh`, `otherBody`).then(response => {
+        expect(response.body).to.include(`already queued`)
+      })
+    })
+  })
 })
 
+function waitUntilRefreshFinishes() {
+  cy.waitUntil(
+    () =>
+      cy
+        .request(`/`)
+        .then(
+          response => !response.body.includes(`<title>Restarting...</title>`)
+        ),
+    {
+      timeout: 60000,
+      interval: 2000,
+    }
+  )
+}

--- a/e2e-tests/development-refresh-endpoint/cypress/support/commands.js
+++ b/e2e-tests/development-refresh-endpoint/cypress/support/commands.js
@@ -1,1 +1,2 @@
 import "@testing-library/cypress/add-commands"
+import "cypress-wait-until"

--- a/e2e-tests/development-refresh-endpoint/package.json
+++ b/e2e-tests/development-refresh-endpoint/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=true gatsby develop",
+    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_RESTARTING_SCREEN_ON_REFRESH=true ENABLE_GATSBY_REFRESH_ENDPOINT=true gatsby develop",
     "serve": "gatsby serve",
     "start": "npm run develop",
     "format": "prettier --write \"src/**/*.js\"",
@@ -33,6 +33,7 @@
     "@testing-library/cypress": "^4.0.4",
     "cross-env": "^5.2.0",
     "cypress": "3.4.1",
+    "cypress-wait-until": "1.7.1",
     "fs-extra": "^7.0.1",
     "gatsby-cypress": "0.4.4",
     "is-ci": "^2.0.0",

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -38,6 +38,10 @@ apiRunnerAsync(`onClientEntry`).then(() => {
           `http://${window.location.hostname}:${services.developstatusserver.port}`
         )
 
+        parentSocket.on(`develop:refresh-started`, msg => {
+          window.location.reload()
+        })
+
         parentSocket.on(`develop:needs-restart`, msg => {
           if (
             window.confirm(

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -204,6 +204,9 @@ module.exports = async (program: IProgram): Promise<void> => {
     if (msg.type === `REFRESH` && msg.action === `FINISHED`) {
       proxy.refreshEnded()
     }
+    if (msg.type === `REFRESH` && msg.action === `STARTED`) {
+      io.emit(`develop:refresh-started`)
+    }
   }
 
   io.on(`connection`, socket => {

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -2,6 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 import { graphql, Link, navigate } from "gatsby"
 import queryString from "query-string"
+import io from "socket.io-client"
 
 class Dev404Page extends React.Component {
   static propTypes = {
@@ -75,6 +76,22 @@ class Dev404Page extends React.Component {
     if (search !== `?${newSearch}`) {
       navigate(`${pathname}?${newSearch}`, { replace: true })
     }
+  }
+
+  componentDidMount() {
+    fetch(`/___services`)
+      .then(res => res.json())
+      .then(services => {
+        if (services.developstatusserver) {
+          const parentSocket = io(
+            `http://${window.location.hostname}:${services.developstatusserver.port}`
+          )
+
+          parentSocket.on(`develop:refresh-started`, msg => {
+            window.location.reload()
+          })
+        }
+      })
   }
 
   render() {

--- a/packages/gatsby/src/utils/develop-proxy.ts
+++ b/packages/gatsby/src/utils/develop-proxy.ts
@@ -120,7 +120,11 @@ export const startDevelopProxy = (input: {
       return
     }
 
+    const canShowRestartingScreenOnRefresh = !!process.env
+      .ENABLE_GATSBY_RESTARTING_SCREEN_ON_REFRESH
+
     if (
+      (isRefreshing && canShowRestartingScreenOnRefresh) ||
       shouldServeRestartingScreen ||
       req.url === `/___debug-restarting-screen`
     ) {


### PR DESCRIPTION
### Description
changes:

- Show the restarting page while data is refreshing can be enabled by setting 

- ENABLE_GATSBY_RESTARTING_SCREEN_ON_REFRESH env variable

### Updated docs with the new env variable
Showing the restarting page is not only useful to have some feedback in the UI about what is going on behind the scenes, but also to be able to make a request to the development server without having to wait.

### Why is this useful?
 This is specially useful for non-developer gatsby-users that use gatsby develop in a preview environment and they need the data up to date, or to know what is going on if data is refreshing.
It is also useful for doing health-checks when having the development server in a container as a preview server. Otherwise health-checks can fail because development server cannot respond while refreshing.

### Why an env variable to enable the restarting screen?
There were some tests making use of the refresh endpoint for the preview, I am not sure that this is something we want to show in all the scenarios, so I created this env variable to be able to opt in.

### Related MR
https://github.com/gatsbyjs/gatsby/pull/24887